### PR TITLE
Apple MIDI

### DIFF
--- a/examples/3. MIDI Interfaces/AppleMIDI/.gitignore
+++ b/examples/3. MIDI Interfaces/AppleMIDI/.gitignore
@@ -1,0 +1,1 @@
+WiFi-Credentials.h

--- a/examples/3. MIDI Interfaces/AppleMIDI/AppleMIDI.ino
+++ b/examples/3. MIDI Interfaces/AppleMIDI/AppleMIDI.ino
@@ -36,6 +36,9 @@
  * software supports mDNS (Apple Bonjour), you can use `ESP32.local`, 
  * otherwise, you'll have to use the IP address.
  * 
+ * RTP MIDI Bridge (Linux)
+ * -----------------------
+ * 
  * If you're on Linux, you can use the rtpmidi-bridge application in the example
  * folder. You'll need to install Node.js and NPM.
  * 
@@ -45,7 +48,7 @@
  * sudo apt install build-essential libasound2-dev libavahi-compat-libdnssd-dev
  * ~~~
  * 
- * Then install the NPM dependencies:
+ * Then install the dependencies using NPM:
  * 
  * ~~~sh
  * npm install

--- a/examples/3. MIDI Interfaces/AppleMIDI/AppleMIDI.ino
+++ b/examples/3. MIDI Interfaces/AppleMIDI/AppleMIDI.ino
@@ -1,0 +1,180 @@
+/**
+ * This example demonstrates how to use the AppleMIDI library to use Control
+ * Surface over the network.
+ * 
+ * @boards  ESP32
+ * 
+ * Connections
+ * -----------
+ * 
+ * The on-board LED will be used, as well as the push button on GPIO0. These 
+ * should be present on most ESP32 boards, if this is not the case for your 
+ * board, connect an LED (+ series resistor) and a push button to the relevant
+ * pins (in the "MIDI Elements" section below). For more details, see the 
+ * @ref NoteButton.ino and @ref 1.Note-LED.ino examples.
+ * 
+ * WiFi Credentials
+ * ----------------
+ * 
+ * Open the tab `WiFi-Credentials.example.h`, enter your WiFi credentials, and
+ * rename the file to `WiFi-Credentials.h`.
+ * 
+ * Behavior
+ * --------
+ * 
+ * Upload the code to the ESP32, and open the Serial monitor. You should see
+ * output like this
+ * 
+ * ~~~
+ * Connecting to Your WiFi Network ...
+ * Connected!
+ * IP address: 192.168.1.35
+ * mDNS responder started (ESP32.local)
+ * ~~~
+ * 
+ * Next, connect to the device using your DAW or other MIDI software. If the 
+ * software supports mDNS (Apple Bonjour), you can use `ESP32.local`, 
+ * otherwise, you'll have to use the IP address.
+ * 
+ * If you're on Linux, you can use the rtpmidi-bridge application in the example
+ * folder. You'll need to install Node.js and NPM.
+ * 
+ * First, install the necessary dependencies and build tools:
+ * 
+ * ~~~sh
+ * sudo apt install build-essential libasound2-dev libavahi-compat-libdnssd-dev
+ * ~~~
+ * 
+ * Then install the NPM dependencies:
+ * 
+ * ~~~sh
+ * npm install
+ * ~~~
+ * You might get a compilation error for the `avahi_pub` module. This is not an
+ * issue, it's an optional dependency of the `rtpmidi` module.
+ * 
+ * Finally, run the application:
+ * 
+ * ~~~sh
+ * node rtpmidi-bridge.js
+ * ~~~
+ * 
+ * The application will initiate a RTP MIDI connection with the ESP32, create
+ * virtual MIDI ports, and bridge the MIDI traffic between the RTP MIDI 
+ * connection and the virtual MIDI ports.  
+ * You can then connect your DAW or other MIDI application to the virtual MIDI 
+ * ports.
+ * 
+ * When the ESP32 is connected, you should see the following in the serial 
+ * monitor and the rtpmidi-bridge output respectively:
+ * 
+ * ~~~
+ * Connected to session Node RTPMidi
+ * ~~~
+ * 
+ * ~~~
+ * 2020-05-06T15:50:42.956Z info:  Invitation accepted by ESP32
+ * 2020-05-06T15:50:42.962Z info:  Data channel to ESP32 established
+ * ~~~
+ * 
+ * When the button is pushed, a MIDI note on message for note C4 (middle C) is
+ * sent.  
+ * When the ESP32 receives a MIDI note message for that note, it turn on/off the
+ * LED accordingly.
+ * 
+ * Mapping
+ * -------
+ * 
+ * Connect the virtual MIDI ports or the AppleMIDI connection to a device or 
+ * application that can send and receive MIDI notes.
+ * 
+ * Written by PieterP, 2020-05-06  
+ * https://github.com/tttapa/Control-Surface
+ */
+
+#include <Control_Surface.h>
+#include <MIDI_Interfaces/Wrappers/FortySevenEffects.hpp>
+
+#include <ESPmDNS.h>
+#include <WiFi.h>
+#include <WiFiUdp.h>
+
+#include "WiFi-Credentials.h" // See instructions above
+
+#include <AppleMIDI.h>
+USING_NAMESPACE_APPLEMIDI
+
+// ----------------------------- MIDI Interface ----------------------------- //
+
+// First create the AppleMIDI instance
+APPLEMIDI_CREATE_INSTANCE(WiFiUDP, MIDI, "ESP32", 5004);
+//                           │       │      │       └──── Local port number
+//                           │       │      └──────────── Name
+//                           │       └─────────────────── MIDI instance name
+//                           └─────────────────────────── Network socket class
+
+// Then wrap it in a Control Surface-compatible MIDI interface
+FortySevenEffectsMIDI_Interface<decltype(MIDI) &> AppleMIDI_interface = MIDI;
+
+// ------------------------------ MIDI Elements ----------------------------- //
+
+// Add some MIDI elements for testing
+using namespace MIDI_Notes;
+NoteButton button = {
+    0, note(C, 4),  // GPIO0 has a push button connected on most boards
+};
+NoteValueLED led = {
+    LED_BUILTIN, note(C, 4),
+};
+
+// --------------------------- AppleMIDI callbacks -------------------------- //
+
+void onAppleMidiConnected(const ssrc_t &ssrc, const char *name) {
+  Serial << F("Connected to session ") << name << endl;
+}
+
+void onAppleMidiDisconnected(const ssrc_t &ssrc) {
+  Serial << F("Disconnected") << endl;
+}
+
+void onAppleMidiError(const ssrc_t &ssrc, int32_t err) {
+  Serial << F("Exception ") << err << F(" from ssrc 0x") << hex << ssrc << dec
+         << endl;
+}
+
+// ---------------------------------- Setup --------------------------------- //
+
+void setup() {
+  Serial.begin(115200);
+
+  // Connect to the WiFi network
+  Serial << endl << F("Connecting to ") << ssid << ' ';
+  WiFi.begin(ssid, password);
+  while (WiFi.status() != WL_CONNECTED)
+    Serial.print("."), delay(250);
+  Serial << endl
+         << F("Connected!") << endl
+         << F("IP address: ") << WiFi.localIP() << endl;
+
+  // Set up mDNS responder:
+  if (!MDNS.begin(AppleMIDI.getName()))
+    FATAL_ERROR(F("Error setting up MDNS responder!"), 0x0032);
+  Serial << F("mDNS responder started (") << AppleMIDI.getName() << ".local)" 
+         << endl;
+  MDNS.addService("apple-midi", "udp", AppleMIDI.getPort());
+
+  // Set up some AppleMIDI callback handles
+  AppleMIDI.setHandleConnected(onAppleMidiConnected);
+  AppleMIDI.setHandleDisconnected(onAppleMidiDisconnected);
+  AppleMIDI.setHandleError(onAppleMidiError);
+
+  // Initialize Control Surface (also calls MIDI.begin())
+  Control_Surface.begin();
+}
+
+// ---------------------------------- Loop ---------------------------------- //
+
+void loop() {
+  // Update all MIDI elements and handle incoming MIDI
+  Control_Surface.loop();
+}

--- a/examples/3. MIDI Interfaces/AppleMIDI/WiFi-Credentials.example.h
+++ b/examples/3. MIDI Interfaces/AppleMIDI/WiFi-Credentials.example.h
@@ -1,0 +1,4 @@
+// Fill in your WiFi credentials and rename this file to "WiFi-Credentials.h".
+
+const char* ssid = "Your WiFi SSID";
+const char* password = "Your WiFi Password";

--- a/examples/3. MIDI Interfaces/AppleMIDI/rtpmidi-bridge/.gitignore
+++ b/examples/3. MIDI Interfaces/AppleMIDI/rtpmidi-bridge/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/3. MIDI Interfaces/AppleMIDI/rtpmidi-bridge/package-lock.json
+++ b/examples/3. MIDI Interfaces/AppleMIDI/rtpmidi-bridge/package-lock.json
@@ -1,0 +1,361 @@
+{
+  "name": "rtpmidi-bridge",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "async": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "requires": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "avahi_pub": {
+      "version": "github:TheThingSystem/node_avahi_pub#5ef863340c5595806ab62995d6b0a0a7b97aba7b",
+      "from": "github:TheThingSystem/node_avahi_pub",
+      "optional": true,
+      "requires": {
+        "bindings": "*",
+        "coffee-script": "*"
+      }
+    },
+    "bindings": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
+      "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
+    },
+    "coffee-script": {
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
+      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
+      "optional": true
+    },
+    "color": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
+      "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
+      "requires": {
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "color-string": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+      "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "colornames": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/colornames/-/colornames-1.1.1.tgz",
+      "integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y="
+    },
+    "colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
+    },
+    "colorspace": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
+      "integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
+      "requires": {
+        "color": "3.0.x",
+        "text-hex": "1.0.x"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "diagnostics": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.1.tgz",
+      "integrity": "sha512-8wn1PmdunLJ9Tqbx+Fx/ZEuHfJf4NKSN2ZBj7SJC/OWRWha843+WsTjqMe1B5E3p28jqBlp+mJ2fPVxPyNgYKQ==",
+      "requires": {
+        "colorspace": "1.1.x",
+        "enabled": "1.0.x",
+        "kuler": "1.0.x"
+      }
+    },
+    "enabled": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
+      "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
+      "requires": {
+        "env-variable": "0.0.x"
+      }
+    },
+    "env-variable": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.6.tgz",
+      "integrity": "sha512-bHz59NlBbtS0NhftmR8+ExBEekE7br0e01jw+kk0NDro7TtZzBYZ5ScGPs3OmwnpyfHTHOtr1Y6uedCdrIldtg=="
+    },
+    "fast-safe-stringify": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
+    },
+    "fecha": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
+      "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg=="
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "kuler": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-1.0.1.tgz",
+      "integrity": "sha512-J9nVUucG1p/skKul6DU3PUZrhs0LPulNaeUOox0IyXDi8S4CztTHs1gQphhuZmzXG7VOQSf6NJfKuzteQLv9gQ==",
+      "requires": {
+        "colornames": "^1.1.1"
+      }
+    },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
+    "logform": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.1.2.tgz",
+      "integrity": "sha512-+lZh4OpERDBLqjiwDLpAWNQu6KMjnlXH2ByZwCuSqVPJletw0kTWJf5CgSNAUKn1KUkv3m2cUz/LK8zyEy7wzQ==",
+      "requires": {
+        "colors": "^1.2.1",
+        "fast-safe-stringify": "^2.0.4",
+        "fecha": "^2.3.3",
+        "ms": "^2.1.1",
+        "triple-beam": "^1.3.0"
+      }
+    },
+    "mdns": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/mdns/-/mdns-2.5.1.tgz",
+      "integrity": "sha512-JglS7Ed3Yf0BCpyC7LXA1MUrumMV8jj4g67nT3+m886SFYllz2HWBg8ObywFXWbBSv5gW0meMOOS4vVa2jZGCw==",
+      "requires": {
+        "bindings": "~1.2.1",
+        "nan": "^2.14.0"
+      }
+    },
+    "midi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/midi/-/midi-1.0.0.tgz",
+      "integrity": "sha512-BL2xedtLEy2ExJujuvQQNs5Gz1aXv7/wpq3KKZ7FmmTvVfR3eC+OgiwtC+4+9IinsXfQnTNSOBrG2PAjMHi0ZQ==",
+      "requires": {
+        "bindings": "~1.5.0",
+        "nan": "^2.3.3"
+      },
+      "dependencies": {
+        "bindings": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+          "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+          "requires": {
+            "file-uri-to-path": "1.0.0"
+          }
+        }
+      }
+    },
+    "midi-common": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/midi-common/-/midi-common-0.0.4.tgz",
+      "integrity": "sha1-OC6/3wXh4oMAutER6a1fB6gf7HI="
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "nan": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+    },
+    "one-time": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-0.0.4.tgz",
+      "integrity": "sha1-+M33eISCb+Tf+T46nMN7HkSAdC4="
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
+    "rtpmidi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rtpmidi/-/rtpmidi-1.0.0.tgz",
+      "integrity": "sha512-baYiQtuWOdrkfjbCFQIcRaYC1Qwl/ounE2opd2hwZh9nndAnQDH/u6C+BuVRKpxJn+ushmFpVcQUQpbYUqBTpw==",
+      "requires": {
+        "avahi_pub": "github:TheThingSystem/node_avahi_pub",
+        "mdns": "2.3.3",
+        "midi-common": "*",
+        "winston": "^3.2.1"
+      },
+      "dependencies": {
+        "mdns": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/mdns/-/mdns-2.3.3.tgz",
+          "integrity": "sha1-u8atVAeiMBM9YuDaaS8p8L1Jco4=",
+          "optional": true,
+          "requires": {
+            "bindings": "~1.2.1",
+            "nan": "~2.3.0"
+          }
+        },
+        "nan": {
+          "version": "2.3.5",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.3.5.tgz",
+          "integrity": "sha1-gioNwmYpDOTNOhIoLKPn42Rmigg=",
+          "optional": true
+        }
+      }
+    },
+    "safe-buffer": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+    },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+    },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+    },
+    "triple-beam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
+      "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "winston": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.2.1.tgz",
+      "integrity": "sha512-zU6vgnS9dAWCEKg/QYigd6cgMVVNwyTzKs81XZtTFuRwJOcDdBg7AU0mXVyNbs7O5RH2zdv+BdNZUlx7mXPuOw==",
+      "requires": {
+        "async": "^2.6.1",
+        "diagnostics": "^1.1.1",
+        "is-stream": "^1.1.0",
+        "logform": "^2.1.1",
+        "one-time": "0.0.4",
+        "readable-stream": "^3.1.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.3.0"
+      }
+    },
+    "winston-transport": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.3.0.tgz",
+      "integrity": "sha512-B2wPuwUi3vhzn/51Uukcao4dIduEiPOcOt9HJ3QeaXgkJ5Z7UwpBzxS4ZGNHtrxrUvTwemsQiSys0ihOf8Mp1A==",
+      "requires": {
+        "readable-stream": "^2.3.6",
+        "triple-beam": "^1.2.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    }
+  }
+}

--- a/examples/3. MIDI Interfaces/AppleMIDI/rtpmidi-bridge/package.json
+++ b/examples/3. MIDI Interfaces/AppleMIDI/rtpmidi-bridge/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "rtpmidi-bridge",
+  "version": "1.0.0",
+  "description": "",
+  "main": "rtpmidi-bridge.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "mdns": "^2.5.1",
+    "midi": "^1.0.0",
+    "rtpmidi": "^1.0.0"
+  }
+}

--- a/examples/3. MIDI Interfaces/AppleMIDI/rtpmidi-bridge/rtpmidi-bridge.js
+++ b/examples/3. MIDI Interfaces/AppleMIDI/rtpmidi-bridge/rtpmidi-bridge.js
@@ -1,0 +1,49 @@
+/**
+ * Code adapted from https://github.com/jdachtera/node-rtpmidi/blob/master/examples/rtpmidi-native-bridge.js
+ * 
+ * This application will initiate a RTP MIDI connection with the ESP32, create
+ * virtual MIDI ports, and bridge the MIDI traffic between the RTP MIDI 
+ * connection and the virtual MIDI ports.  
+ * You can then connect your DAW or other MIDI application to the virtual MIDI 
+ * ports.
+ * 
+ * To install the dependencies, see the instructions in the Arduino sketch
+ * documentation, one level up.
+ */
+
+const midi = require('midi');
+const rtpmidi = require('rtpmidi');
+
+const input = new midi.input();
+const output = new midi.output();
+
+const session = rtpmidi.manager.createSession({
+  localName: 'Session 1',
+  bonjourName: 'Node RTPMidi',
+  port: 5004,
+});
+
+// Enable some console output;
+// rtpmidi.log.level = 4;
+
+// Create the virtual midi ports
+input.openVirtualPort('RTP MIDI Virtual Input');
+output.openVirtualPort('RTP MIDI Virtual Output');
+
+// Route the messages
+session.on('message', (deltaTime, message) => {
+  // message is a Buffer so we convert it to an array to pass it to the midi output.
+  const commands = Array.prototype.slice.call(message, 0);
+  // console.log('received a network message', commands);
+  output.sendMessage(commands);
+});
+
+input.on('message', (deltaTime, message) => {
+  // console.log('received a local message', message);
+  session.sendMessage(deltaTime, message);
+});
+
+// Connect to a remote session
+session.connect({ address: 'ESP32.local', port: 5004 });
+//                            └─── this name should match the AppleMIDI name in
+//                                 your Arduino sketch

--- a/examples/examples.dox
+++ b/examples/examples.dox
@@ -606,6 +606,55 @@
  */
 
 /**
+ * @example   "Bankable-Smart-Control-Change-Potentiometer.ino"
+ * 
+ * Bankable-Smart-Control-Change-Potentiometer
+ * ===========================================
+ * 
+ * This example introduces smart bankable potentiometers to prevent
+ * values jumping around when changing banks.
+ *  
+ * @boards  AVR, AVR USB, Nano Every, Due, Nano 33, Teensy 3.x, ESP32
+ * 
+ * Connections
+ * -----------
+ * 
+ * - A0: wiper of a potentiometer
+ * - 2:  momentary push button (other pin to ground)
+ * - 3:  momentary push button (other pin to ground)
+ * 
+ * Connect the left terminal of the potentiometer to ground, and the right one
+ * to V<sub>CC</sub>.  
+ * The internal pull-up resistors for the push buttons will be enabled.
+ * 
+ * Behavior
+ * --------
+ * 
+ * If you move the potentiometer to, say, 60%, then switch to bank #2, move the
+ * potentiometer to 20%, and then switch back to bank #1, the potentiometer will
+ * be disabled, until you move it up to 60% again.
+ * 
+ * This prevents values jumping around in your DAW when cycling through the
+ * different banks.
+ * 
+ * Changing banks is done using the two push buttons. The push button on pin 2
+ * increments the bank number, the push button on pin 3 decrements the bank 
+ * number.
+ * 
+ * Mapping
+ * -------
+ * 
+ * Select the Arduino as a custom MIDI controller in your DAW, and use the 
+ * MIDI learn option to assign the potentiometer to a function, change the  
+ * bank using the buttons, and map the potentiometer again.
+ * It will send the MIDI Control Change Channel Volume parameter for channels 
+ * 1, 2, 3 and 4 (for banks #1, #2, #3 and #4 respectively).
+ * 
+ * Written by PieterP, 2020-04-09  
+ * https://github.com/tttapa/Control-Surface
+ */
+
+/**
  * @example   "Transposer.ino"
  * 
  * Transposer
@@ -692,6 +741,108 @@
  * None.
  * 
  * Written by PieterP, 2020-02-03  
+ * https://github.com/tttapa/Control-Surface
+ */
+
+/**
+ * @example   "AppleMIDI.ino"
+ * 
+ * AppleMIDI
+ * =========
+ *
+ * This example demonstrates how to use the AppleMIDI library to use Control
+ * Surface over the network.
+ * 
+ * @boards  ESP32
+ * 
+ * Connections
+ * -----------
+ * 
+ * The on-board LED will be used, as well as the push button on GPIO0. These 
+ * should be present on most ESP32 boards, if this is not the case for your 
+ * board, connect an LED (+ series resistor) and a push button to the relevant
+ * pins (in the "MIDI Elements" section below). For more details, see the 
+ * @ref NoteButton.ino and @ref 1.Note-LED.ino examples.
+ * 
+ * WiFi Credentials
+ * ----------------
+ * 
+ * Open the tab `WiFi-Credentials.example.h`, enter your WiFi credentials, and
+ * rename the file to `WiFi-Credentials.h`.
+ * 
+ * Behavior
+ * --------
+ * 
+ * Upload the code to the ESP32, and open the Serial monitor. You should see
+ * output like this
+ * 
+ * ~~~
+ * Connecting to Your WiFi Network ...
+ * Connected!
+ * IP address: 192.168.1.35
+ * mDNS responder started (ESP32.local)
+ * ~~~
+ * 
+ * Next, connect to the device using your DAW or other MIDI software. If the 
+ * software supports mDNS (Apple Bonjour), you can use `ESP32.local`, 
+ * otherwise, you'll have to use the IP address.
+ * 
+ * RTP MIDI Bridge (Linux)
+ * -----------------------
+ * 
+ * If you're on Linux, you can use the rtpmidi-bridge application in the example
+ * folder. You'll need to install Node.js and NPM.
+ * 
+ * First, install the necessary dependencies and build tools:
+ * 
+ * ~~~sh
+ * sudo apt install build-essential libasound2-dev libavahi-compat-libdnssd-dev
+ * ~~~
+ * 
+ * Then install the dependencies using NPM:
+ * 
+ * ~~~sh
+ * npm install
+ * ~~~
+ * You might get a compilation error for the `avahi_pub` module. This is not an
+ * issue, it's an optional dependency of the `rtpmidi` module.
+ * 
+ * Finally, run the application:
+ * 
+ * ~~~sh
+ * node rtpmidi-bridge.js
+ * ~~~
+ * 
+ * The application will initiate a RTP MIDI connection with the ESP32, create
+ * virtual MIDI ports, and bridge the MIDI traffic between the RTP MIDI 
+ * connection and the virtual MIDI ports.  
+ * You can then connect your DAW or other MIDI application to the virtual MIDI 
+ * ports.
+ * 
+ * When the ESP32 is connected, you should see the following in the serial 
+ * monitor and the rtpmidi-bridge output respectively:
+ * 
+ * ~~~
+ * Connected to session Node RTPMidi
+ * ~~~
+ * 
+ * ~~~
+ * 2020-05-06T15:50:42.956Z info:  Invitation accepted by ESP32
+ * 2020-05-06T15:50:42.962Z info:  Data channel to ESP32 established
+ * ~~~
+ * 
+ * When the button is pushed, a MIDI note on message for note C4 (middle C) is
+ * sent.  
+ * When the ESP32 receives a MIDI note message for that note, it turn on/off the
+ * LED accordingly.
+ * 
+ * Mapping
+ * -------
+ * 
+ * Connect the virtual MIDI ports or the AppleMIDI connection to a device or 
+ * application that can send and receive MIDI notes.
+ * 
+ * Written by PieterP, 2020-05-06  
  * https://github.com/tttapa/Control-Surface
  */
 
@@ -1714,6 +1865,46 @@
  * None.
  * 
  * Written by PieterP, 2019-10-10  
+ * https://github.com/tttapa/Control-Surface
+ */
+
+/**
+ * @example   "Custom-MIDI-Sender.ino"
+ * 
+ * Custom-MIDI-Sender
+ * ==================
+ * 
+ * This is an example that demonstrates how to extend the library using your own
+ * MIDI Senders. It implements functionality similar to the built-in 
+ * @ref DigitalNoteSender class, but with support for different on and off 
+ * velocities.
+ * 
+ * @see @ref MIDI_Senders for different kinds of MIDI senders to start from.
+ *
+ * @boards  AVR, AVR USB, Due, Nano 33, Teensy 3.x, ESP32
+ * 
+ * Connections
+ * -----------
+ * 
+ * - 5: momentary push button (to ground)
+ * 
+ * The internal pull-up resistor for the button will be enabled automatically.
+ * 
+ * Behavior
+ * --------
+ * 
+ * - When the button on pin 5 is pressed, a MIDI Note On message is sent for
+ *   note C4 with velocity 0x40.
+ * - When the button on pin 5 is released, a MIDI Note Off message is sent for 
+ *   note C4 with velocity 0x10.
+ * 
+ * Mapping
+ * -------
+ * 
+ * Select the Arduino as a custom MIDI controller in your DAW, and use the 
+ * MIDI learn option to assign the button to a function.
+ * 
+ * Written by PieterP, 2020-04-18  
  * https://github.com/tttapa/Control-Surface
  */
 

--- a/keywords.txt
+++ b/keywords.txt
@@ -828,6 +828,7 @@ SoftwareSerialDebugMIDI_Interface	KEYWORD1
 HairlessMIDI_Interface	KEYWORD1
 MIDI_Callbacks	KEYWORD1
 SysExMessage	KEYWORD1
+FortySevenEffectsMIDI_Interface	KEYWORD1
 
 begin	KEYWORD2
 update	KEYWORD2

--- a/scripts/install-ci.sh
+++ b/scripts/install-ci.sh
@@ -57,5 +57,14 @@ else
     make install PREFIX=$HOME/.local
 fi
 
+cd ~/Arduino/libraries
+if [ ! -d WiFi-Credentials ]; then
+    mkdir WiFi-Credentials
+    cat << EOF > WiFi-Credentials/WiFi-Credentials.h
+const char *ssid = "Your WiFi SSID";
+const char *password = "Your WiFi Password";
+EOF
+fi
+
 ln -s "${TRAVIS_BUILD_DIR}${GITHUB_WORKSPACE}" \
       "$HOME/Arduino/libraries/Control-Surface"

--- a/scripts/install-ci.sh
+++ b/scripts/install-ci.sh
@@ -40,7 +40,9 @@ else
     git clone https://github.com/tttapa/Adafruit_SSD1306.git &
     git clone https://github.com/PaulStoffregen/Encoder.git &
     git clone https://github.com/FastLED/FastLED.git &
-    git clone https://github.com/arduino-libraries/MIDIUSB.git
+    git clone https://github.com/arduino-libraries/MIDIUSB.git &
+    git clone https://github.com/lathoub/Arduino-AppleMIDI-Library.git &
+    git clone https://github.com/FortySevenEffects/arduino_midi_library.git &
 
     wait
 fi

--- a/src/MIDI_Interfaces/Wrappers/FortySevenEffects.hpp
+++ b/src/MIDI_Interfaces/Wrappers/FortySevenEffects.hpp
@@ -1,0 +1,126 @@
+#pragma once
+
+#include <AH/Error/Error.hpp>
+#include <MIDI_Interfaces/MIDI_Interface.hpp>
+
+AH_DIAGNOSTIC_WERROR()
+
+AH_DIAGNOSTIC_EXTERNAL_HEADER()
+#include <MIDI.h>
+AH_DIAGNOSTIC_POP()
+
+BEGIN_CS_NAMESPACE
+
+/**
+ * @brief   Wrapper class for the FortySevenEffects MIDI parser.
+ * 
+ * @see @ref FortySevenEffectsMIDI_Interface
+ */
+class FortySevenEffectsMIDI_Parser : public MIDI_Parser {
+  private:
+    template <class MidiInterface>
+    friend class FortySevenEffectsMIDI_Interface;
+
+    /// Get the latest channel message from the given MIDI interface.
+    template <class MidiInterface>
+    void updateChannelMessage(const MidiInterface &interface) {
+        uint8_t channel = interface.getChannel() - 1;
+        this->midimsg.header = interface.getType() | channel;
+        this->midimsg.data1 = interface.getData1();
+        this->midimsg.data2 = interface.getData2();
+        this->midimsg.CN = 0;
+    }
+
+    /// Get the latest system exclusive message from teh given MIDI interface.
+    template <class MidiInterface>
+    void updateSysExMessage(const MidiInterface &interface) {
+        this->sysex.data = interface.getSysExArray();
+        this->sysex.length = interface.getSysExArrayLength();
+        this->sysex.CN = 0;
+    }
+
+    /// Temporarily saves a pointer to the MIDI parser's SysEx buffer.
+    SysExMessage sysex = {nullptr, 0, 0};
+
+  public:
+    SysExMessage getSysEx() const override { return sysex; }
+};
+
+/**
+ * @brief   Class that wraps the FortySevenEffects MIDI library. 
+ * 
+ * This wrapper allows you to use MIDI interfaces that inherit from the 
+ * FortySevenEffects MIDI library as a native Control Surface MIDI Interface.
+ * 
+ * It's not recommended to use this wrapper for normal Serial or USB MIDI 
+ * interfaces, you should use the @ref HardwareSerialMIDI_Interface and 
+ * @ref USBMIDI_Interface classes for that (see @ref MIDIInterfaces).
+ * 
+ * It can be useful, however, to use the AppleMIDI library, which uses the 
+ * FortySevenEffects MidiInterface as its main public API. 
+ * 
+ * @tparam  MidiInterface
+ *          The type of FortySevenEffects MIDI interface to use. You should
+ *          probably just use `decltype` as demonstrated in the 
+ *          @ref AppleMIDI.ino example.
+ * 
+ * @ingroup MIDIInterfaces
+ */
+template <class MidiInterface>
+class FortySevenEffectsMIDI_Interface : public Parsing_MIDI_Interface {
+  public:
+    FortySevenEffectsMIDI_Interface(MidiInterface &&midi)
+        : Parsing_MIDI_Interface(parser),
+          midi(std::forward<MidiInterface>(midi)) {}
+
+    void begin() override { midi.begin(MIDI_CHANNEL_OMNI); }
+
+    MIDI_read_t read() override {
+        if (!midi.read())      // Update the MIDI input and check if there's
+            return NO_MESSAGE; // a new message available
+        auto type = midi.getType();
+        if (midi.isChannelMessage(type)) { // Channel
+            parser.updateChannelMessage(midi);
+            return CHANNEL_MESSAGE;
+        }
+        if (type == SysExStart) { // SysEx
+            parser.updateSysExMessage(midi);
+            return SYSEX_MESSAGE;
+        }
+        if (type >= TIMING_CLOCK_MESSAGE) { // Real-Time
+            return static_cast<MIDI_read_t>(type);
+        }
+        return NO_MESSAGE;
+    }
+
+  protected:
+    void sendImpl(uint8_t m, uint8_t c, uint8_t d1, uint8_t d2,
+                  uint8_t cn) override {
+        // channel is zero-based in Control Surface, one-based in MIDI 47 Fx
+        midi.send(static_cast<MIDI_NAMESPACE::MidiType>(m), d1, d2, c + 1);
+        (void)cn;
+    }
+    void sendImpl(uint8_t m, uint8_t c, uint8_t d1, uint8_t cn) override {
+        // channel is zero-based in Control Surface, one-based in MIDI 47 Fx
+        midi.send(static_cast<MIDI_NAMESPACE::MidiType>(m), d1, 0, c + 1);
+        // MIDI 47 Fx checks message type to handle 2-byte messages separately
+        (void)cn;
+    }
+    void sendImpl(const uint8_t *data, size_t length, uint8_t cn) {
+        midi.sendSysEx(length, data, true);
+        // true indicates that the array contains the SysEx start and stop bytes
+        (void)cn;
+    }
+    void sendImpl(uint8_t rt, uint8_t cn) override {
+        midi.sendRealTime(static_cast<MIDI_NAMESPACE::MidiType>(rt));
+        (void)cn;
+    }
+
+  private:
+    FortySevenEffectsMIDI_Parser parser;
+    MidiInterface midi;
+};
+
+END_CS_NAMESPACE
+
+AH_DIAGNOSTIC_POP()

--- a/src/MIDI_Interfaces/keywords.yml
+++ b/src/MIDI_Interfaces/keywords.yml
@@ -13,6 +13,7 @@ keyword1:
  - HairlessMIDI_Interface
  - MIDI_Callbacks
  - SysExMessage
+ - FortySevenEffectsMIDI_Interface
 
 keyword2:
  - begin


### PR DESCRIPTION
This PR adds support for the AppleMIDI library and other libraries that follow the FortySevenEffects MIDI API.  
This is done through a thin wrapper that exposes the AppleMIDI functions for sending and receiving MIDI according to the usual MIDI_Interface interface that's used throughout the Control Surface library.

It also includes an AppleMIDI example for the ESP32, as well as a Node.js script to connect to the RTP MIDI session from a Linux machine.