### PR TITLE
Add ManyAddresses NoteButtonLatched

### DIFF
--- a/src/Control_Surface.h
+++ b/src/Control_Surface.h
@@ -66,6 +66,7 @@
 #include <MIDI_Outputs/Bankable/NoteButtons.hpp>
 #include <MIDI_Outputs/Bankable/NoteChordButton.hpp>
 #include <MIDI_Outputs/ManyAddresses/NoteButton.hpp>
+#include <MIDI_Outputs/ManyAddresses/NoteButtonLatched.hpp>
 #include <MIDI_Outputs/ManyAddresses/NoteButtonMatrix.hpp>
 
 #include <MIDI_Outputs/Bankable/PBPotentiometer.hpp>

--- a/src/MIDI_Outputs/ManyAddresses/NoteButtonLatched.cpp
+++ b/src/MIDI_Outputs/ManyAddresses/NoteButtonLatched.cpp
@@ -1,0 +1,3 @@
+#ifdef TEST_COMPILE_ALL_HEADERS_SEPARATELY
+#include "NoteButton.hpp"
+#endif

--- a/src/MIDI_Outputs/ManyAddresses/NoteButtonLatched.hpp
+++ b/src/MIDI_Outputs/ManyAddresses/NoteButtonLatched.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <Banks/BankAddresses.hpp>
+#include <MIDI_Outputs/Bankable/Abstract/MIDIButtonLatched.hpp>
+#include <MIDI_Senders/DigitalNoteSender.hpp>
+
+BEGIN_CS_NAMESPACE
+namespace Bankable {
+namespace ManyAddresses {
+
+/**
+ * @brief   A class of MIDIOutputElement%s that read the input of a **momentary
+ *          push button or switch**, and send out MIDI **Note** event.
+ *
+ * A Note On event is sent when the button is pressed
+ * The button is debounced in software.
+ * This version can be banked using an arbitrary list of alternative
+ * addresses.
+ *
+ * @tparam  NumBanks
+ *          The number of variants/alternative addresses the element has.
+ *
+ * @ingroup ManyAddressesMIDIOutputElements
+ */
+template <setting_t NumBanks>
+class NoteButtonLatched
+    : public Bankable::MIDIButtonLatched<ManyAddresses<NumBanks>, SingleAddress, DigitalNoteSender> {
+  public:
+    /**
+     * @brief   Create a new Bankable NoteButtonLatched object with the given bank
+     *          configuration, button pin, and address.
+     *
+     * @param   bank
+     *          The bank that selects the address to use.
+     * @param   pin
+     *          The digital input pin with the button connected.
+     *          The internal pull-up resistor will be enabled.
+     * @param   addresses
+     *          The list of MIDI addresses containing the note number
+     *          [0, 127], channel [CHANNEL_1, CHANNEL_16], and optional cable
+     *          number [0, 15].
+     * @param   velocity
+     *          The velocity of the MIDI Note events.
+     *
+     * @ingroup MIDIOutputElementConstructors
+     */
+    NoteButtonLatched(const Bank<NumBanks> &bank, pin_t pin,
+               const Array<MIDIAddress, NumBanks> &addresses,
+               uint8_t velocity = 0x7F)
+        : MIDIButtonLatched<ManyAddresses<NumBanks>, SingleAddress, DigitalNoteSender>{
+              {bank, addresses}, pin, {velocity}} {}
+};
+
+} // namespace ManyAddresses
+} // namespace Bankable
+
+END_CS_NAMESPACE


### PR DESCRIPTION
Hi Pieter,

I tried to create the `ManyAddressess::NoteButtonLatched` class, but got some errors...

Here the code I use to test
```cc
#include <Control_Surface.h>
 
// :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::: //
 
// Instantiate a MIDI over USB interface.
USBMIDI_Interface midi;
 
using namespace MIDI_Notes;
 
// Function buttons
// Create a Bank object to select one of three modes (REC, MUTE, SOLO)
Bank<3> bank;

// Create a Selector object that reads a push button connected to pin 10
// to select which mode is active.
IncrementSelector<3> pushbutton = {bank, 10};

Bankable::ManyAddresses::NoteButtonLatched<3> button = {
  bank, // bank selects active address
  7,    // push button pin
  {{    // addresses
    MCU::REC_RDY_1,
    MCU::MUTE_1,
    MCU::SOLO_1,
  }},
};

void setup() {
  Control_Surface.begin(); // Initialize Control Surface (calls button.begin())
}
 
void loop() {
  Control_Surface.loop(); // Update the Control Surface (calls button.update())

  // Function button
  static setting_t prevSetting = -1;
  setting_t setting = bank.getSelection();
  if (setting != prevSetting) {
    const char *mode;
    switch (setting) {
      case 0: mode = "REC"; break;
      case 1: mode = "MUTE"; break;
      case 2: mode = "SOLO"; break;
      default: mode = "<invalid>";
    }
    Serial.println(mode);
    prevSetting = setting;
  }
}
```

Compilation errors:

```cc
In file included from /home/red/Arduino/libraries/Control-Surface/src/Control_Surface.h:69:0,
                 from /home/red/Arduino/projets/MIDI/MIDI_MCU_ManyAddresses/MIDI_MCU_ManyAddresses.ino:2:
/home/red/Arduino/libraries/Control-Surface/src/MIDI_Outputs/ManyAddresses/NoteButtonLatched.hpp:27:99: error: type/value mismatch at argument 1 in template parameter list for 'template<unsigned char NumBanks, class BankAddress, class Sender> class CS::Bankable::MIDIButtonLatched'
     : public Bankable::MIDIButtonLatched<ManyAddresses<NumBanks>, SingleAddress, DigitalNoteSender> {
                                                                                                   ^
/home/red/Arduino/libraries/Control-Surface/src/MIDI_Outputs/ManyAddresses/NoteButtonLatched.hpp:27:99: note:   expected a constant of type 'unsigned char', got 'CS::Bankable::ManyAddresses::ManyAddresses<NumBanks>'
/home/red/Arduino/libraries/Control-Surface/src/MIDI_Outputs/ManyAddresses/NoteButtonLatched.hpp: In constructor 'CS::Bankable::ManyAddresses::NoteButtonLatched<NumBanks>::NoteButtonLatched(const CS::Bank<N>&, AH::pin_t, const AH::Array<CS::MIDIAddress, NumBanks>&, uint8_t)':
/home/red/Arduino/libraries/Control-Surface/src/MIDI_Outputs/ManyAddresses/NoteButtonLatched.hpp:50:86: error: type/value mismatch at argument 1 in template parameter list for 'template<unsigned char NumBanks, class BankAddress, class Sender> class CS::Bankable::MIDIButtonLatched'
         : MIDIButtonLatched<ManyAddresses<NumBanks>, SingleAddress, DigitalNoteSender>{
                                                                                      ^
/home/red/Arduino/libraries/Control-Surface/src/MIDI_Outputs/ManyAddresses/NoteButtonLatched.hpp:50:86: note:   expected a constant of type 'unsigned char', got 'CS::Bankable::ManyAddresses::ManyAddresses<NumBanks>'
/home/red/Arduino/libraries/Control-Surface/src/MIDI_Outputs/ManyAddresses/NoteButtonLatched.hpp:51:31: error: expected ';' before '}' token
               {bank, addresses}, pin, {velocity}} {}
                               ^
/home/red/Arduino/libraries/Control-Surface/src/MIDI_Outputs/ManyAddresses/NoteButtonLatched.hpp:51:32: error: expected primary-expression before ',' token
               {bank, addresses}, pin, {velocity}} {}
                                ^
/home/red/Arduino/libraries/Control-Surface/src/MIDI_Outputs/ManyAddresses/NoteButtonLatched.hpp:51:39: error: expected primary-expression before '{' token
               {bank, addresses}, pin, {velocity}} {}
                                       ^
/home/red/Arduino/libraries/Control-Surface/src/MIDI_Outputs/ManyAddresses/NoteButtonLatched.hpp: In instantiation of 'CS::Bankable::ManyAddresses::NoteButtonLatched<NumBanks>::NoteButtonLatched(const CS::Bank<N>&, AH::pin_t, const AH::Array<CS::MIDIAddress, NumBanks>&, uint8_t) [with unsigned char NumBanks = 3u; AH::pin_t = short unsigned int; uint8_t = unsigned char]':
/home/red/Arduino/projets/MIDI/MIDI_MCU_ManyAddresses/MIDI_MCU_ManyAddresses.ino:27:1:   required from here
/home/red/Arduino/libraries/Control-Surface/src/MIDI_Outputs/ManyAddresses/NoteButtonLatched.hpp:51:20: warning: left operand of comma operator has no effect [-Wunused-value]
               {bank, addresses}, pin, {velocity}} {}
                    ^
/home/red/Arduino/libraries/Control-Surface/src/MIDI_Outputs/ManyAddresses/NoteButtonLatched.hpp:51:16: warning: right operand of comma operator has no effect [-Wunused-value]
               {bank, addresses}, pin, {velocity}} {}
                ^
Error compiling for board Teensy 4.0.

```

If you have any idea.

Many thanks!