### PR TITLE
Use size_t instead of uint8_t for sysex length

### DIFF
--- a/src/MIDI_Parsers/MIDI_MessageTypes.hpp
+++ b/src/MIDI_Parsers/MIDI_MessageTypes.hpp
@@ -154,7 +154,7 @@ struct SysExMessage {
 #endif
 
     const uint8_t *data;
-    uint8_t length;
+    size_t length;
     uint8_t CN;
 
     bool operator==(SysExMessage other) const {


### PR DESCRIPTION
The size of a sysex message should be typed size_t instead of uint8 to allow longer sysex messages. Currently increasing SYSEX_BUFFER_SIZE in Settings.hpp does not work as expected, changing the length type to size_t solves the problem and allows handling larger sysex messages.