### PR TITLE
Add support for reading from CD74HC165 shift-in register

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ __pycache__/
 *.hex
 
 docs
+
+.DS_Store

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -19,6 +19,19 @@
         },
         {
             "type": "shell",
+            "label": "Make All (Mac)",
+            "command": "make -j$[$(sysctl -n hw.logicalcpu) * 2]",
+            "options": {
+                "cwd": "${workspaceFolder}/build",
+            },
+            "problemMatcher": "$gcc",
+            "group": {
+                "kind": "build",
+                "isDefault": true,
+            },
+        },
+        {
+            "type": "shell",
             "label": "Clear Build Directory and Run CMake",
             "command": "./setup-build.sh \"${workspaceFolder}\"",
             "options": {
@@ -35,6 +48,17 @@
                 "cwd": "${workspaceFolder}/build",
             },
             "dependsOn": "Make All",
+            "problemMatcher": "$gcc",
+            "group": "test",
+        },
+        {
+            "type": "shell",
+            "label": "Make Test (Mac)",
+            "command": "make test",
+            "options": {
+                "cwd": "${workspaceFolder}/build",
+            },
+            "dependsOn": "Make All (Mac)",
             "problemMatcher": "$gcc",
             "group": "test",
         },
@@ -58,6 +82,17 @@
                 "cwd": "${workspaceFolder}/scripts",
             },
             "dependsOn": "Make Test",
+            "group": "test",
+        },
+        {
+            "type": "shell",
+            "label": "Make & Test & Build examples (Mac)",
+            "command": "./build-arduino-examples.sh $[$(sysctl -n hw.logicalcpu) * 2]",
+            "problemMatcher": "$gcc",
+            "options": {
+                "cwd": "${workspaceFolder}/scripts",
+            },
+            "dependsOn": "Make Test (Mac)",
             "group": "test",
         },
         // Documentation & Coverage ::::::::::::::::::::::::::::::::::::::::::::

--- a/src/AH/Hardware/ExtendedInputOutput/ShiftRegisterIn.cpp
+++ b/src/AH/Hardware/ExtendedInputOutput/ShiftRegisterIn.cpp
@@ -1,0 +1,3 @@
+#ifdef TEST_COMPILE_ALL_HEADERS_SEPARATELY
+#include "ShiftRegisterIn.hpp"
+#endif

--- a/src/AH/Hardware/ExtendedInputOutput/ShiftRegisterIn.hpp
+++ b/src/AH/Hardware/ExtendedInputOutput/ShiftRegisterIn.hpp
@@ -13,11 +13,8 @@ AH_DIAGNOSTIC_WERROR() // Enable errors on warnings
 BEGIN_AH_NAMESPACE
 
 /**
- * @brief   A class for reading multiplexed analog inputs.
- *          Supports 74HC4067, 74HC4051, etc.
- * 
- * You can use many multiplexers on the same address lines if each of the 
- * multiplexers has a different enable line.
+ * @brief   A class for reading multiplexed digital inputs.
+ *          Supports CD74HC165
  * 
  * @tparam  N 
  *          The number of addressable pins.
@@ -31,15 +28,14 @@ class ShiftRegisterIn : public StaticSizeExtendedIOElement<N> {
      * @brief   Create a new ShiftRegisterIn object on the given pins.
      * 
      * @param   dataPin
-     *          The analog input pin connected to the output of the multiplexer.
-     * @param   addressPins
-     *          An array of the pins connected to the address lines of the
-     *          multiplexer. (Labeled S0, S1, S2 ... in the datasheet.)
-     * @param   enablePin
-     *          The digital output pin connected to the enable pin of the
-     *          multiplexer. (Labeled Ē in the datasheet.)  
-     *          If you don't need the enable pin, you can use NO_PIN, which is 
-     *          the default.
+     *          The pin used to read data from the shift register.
+     * @param   clockPin
+     *          The pin that send clock pules to the shift register.
+     * @param   clockEnablePin
+     *          The pin that enables the clock on the shift register.
+     * @param   loadPin
+     *          The pin that loads inputs from devices connected to the shift
+     *          register.
      */
     ShiftRegisterIn(pin_t dataPin, pin_t clockPin, pin_t clockEnablePin, 
                     pin_t loadPin)
@@ -49,18 +45,16 @@ class ShiftRegisterIn : public StaticSizeExtendedIOElement<N> {
          }
 
     /**
-     * @brief   Set the pin mode of the analog input pin.  
-     *          This allows you to enable the internal pull-up resistor, for
-     *          use with buttons or open-collector outputs.
+     * @brief   Set the pin mode of the data pin.
      * 
-     * @note    This applies to all pins of this multiplexer.  
-     *          This affects all pins of the multiplexer, because it has only
-     *          a single common pin.  
+     * @note    This method should not be called because you cannot
+     *          effectively set the pin mode of the inputs to the shift
+     *          register.
      * 
      * @param   pin
      *          (Unused)
      * @param   mode
-     *          The new mode of the input pin: 
+     *          The new mode of the data pin: 
      *          either INPUT or INPUT_PULLUP.
      */
     void pinMode(pin_t pin, PinMode_t mode) override;
@@ -72,7 +66,7 @@ class ShiftRegisterIn : public StaticSizeExtendedIOElement<N> {
 
     /**
      * @brief   The digitalWrite function is not implemented because writing an
-     *          output to a multiplexer is not useful.
+     *          output to a shift-in register is not useful.
      */
     void digitalWrite(pin_t, PinStatus_t) override // LCOV_EXCL_LINE
         __attribute__((deprecated)) {}             // LCOV_EXCL_LINE
@@ -87,7 +81,7 @@ class ShiftRegisterIn : public StaticSizeExtendedIOElement<N> {
      * @brief   Read the digital state of the given input.
      * 
      * @param   pin
-     *          The multiplexer's pin number to read from.
+     *          The shift register's pin number to read from.
      */
     int digitalRead(pin_t pin) override;
 
@@ -99,8 +93,11 @@ class ShiftRegisterIn : public StaticSizeExtendedIOElement<N> {
     /**
      * @brief   Read the analog value of the given input.
      * 
+     * @note    This method should not be called because shift
+     *          registers do not have analog inputs.
+     * 
      * @param   pin
-     *          The multiplexer's pin number to read from.
+     *          The shift register's pin number to read from.
      */
     analog_t analogRead(pin_t pin) override;
 
@@ -111,7 +108,7 @@ class ShiftRegisterIn : public StaticSizeExtendedIOElement<N> {
 
     /**
      * @brief   The analogWrite function is not implemented because writing an
-     *          output to a multiplexer is not useful.
+     *          output to a shift register is not useful.
      */
     void analogWrite(pin_t, analog_t) override // LCOV_EXCL_LINE
         __attribute__((deprecated)) {}         // LCOV_EXCL_LINE
@@ -123,7 +120,7 @@ class ShiftRegisterIn : public StaticSizeExtendedIOElement<N> {
         __attribute__((deprecated)) {}                 // LCOV_EXCL_LINE
 
     /**
-     * @brief   Initialize the multiplexer: set the pin mode of the address pins
+     * @brief   Initialize the shift register: set the pin mode of the address pins
      *          and the enable pin to output mode.
      */
     void begin() override;
@@ -136,6 +133,11 @@ class ShiftRegisterIn : public StaticSizeExtendedIOElement<N> {
      */
     void updateBufferedOutputs() override {} // LCOV_EXCL_LINE
 
+    /**
+     * @brief   Reads the current values of the inputs connected to the shift
+     *          register and stores them for retrieval via digitalRead.
+     * 
+     */
     void updateBufferedInputs() override;
 
   private:
@@ -158,7 +160,7 @@ class ShiftRegisterIn : public StaticSizeExtendedIOElement<N> {
 };
 
 /**
- * @brief   An alias for ShiftRegisterIn<3> to use with CD74HC165 shift 
+ * @brief   An alias for ShiftRegisterIn<8> to use with CD74HC165 shift 
  *          registers.
  * 
  * @ingroup AH_ExtIO
@@ -189,7 +191,8 @@ int ShiftRegisterIn<N>::digitalReadBuffered(pin_t pin) {
 
 template <uint8_t N>
 analog_t ShiftRegisterIn<N>::analogRead(pin_t pin) {
-    return pin;
+    // shift registers do not have analog inputs, so always return 0
+    return 0;
 }
 
 template <uint8_t N>

--- a/src/AH/Hardware/ExtendedInputOutput/ShiftRegisterIn.hpp
+++ b/src/AH/Hardware/ExtendedInputOutput/ShiftRegisterIn.hpp
@@ -186,6 +186,8 @@ int ShiftRegisterIn<N>::digitalRead(pin_t pin) {
 
 template <uint8_t N>
 int ShiftRegisterIn<N>::digitalReadBuffered(pin_t pin) {
+    // ISSUE: bitRead is available when building for Arduino but not when 
+    // running tests
     return bitRead(buffer, pin);
 }
 
@@ -215,6 +217,8 @@ template <uint8_t N>
 void ShiftRegisterIn<N>::updateBufferedInputs() {
     prepareReading();
     
+    // ISSUE: shiftIn is available when building for Arduino but not when
+    // running tests
     buffer = shiftIn(dataPin, clockPin, LSBFIRST);
 
     afterReading();

--- a/src/AH/Hardware/ExtendedInputOutput/ShiftRegisterIn.hpp
+++ b/src/AH/Hardware/ExtendedInputOutput/ShiftRegisterIn.hpp
@@ -192,7 +192,7 @@ int ShiftRegisterIn<N>::digitalReadBuffered(pin_t pin) {
 }
 
 template <uint8_t N>
-analog_t ShiftRegisterIn<N>::analogRead(pin_t pin) {
+analog_t ShiftRegisterIn<N>::analogRead(__attribute__((unused)) pin_t pin) {
     // shift registers do not have analog inputs, so always return 0
     return 0;
 }

--- a/src/AH/Hardware/ExtendedInputOutput/ShiftRegisterIn.hpp
+++ b/src/AH/Hardware/ExtendedInputOutput/ShiftRegisterIn.hpp
@@ -1,0 +1,234 @@
+/* ✔ */
+
+#pragma once
+
+#include <AH/Settings/Warnings.hpp>
+AH_DIAGNOSTIC_WERROR() // Enable errors on warnings
+
+#include "ExtendedInputOutput.hpp"
+#include "StaticSizeExtendedIOElement.hpp"
+#include <AH/Containers/Array.hpp>
+#include <stdlib.h>
+
+BEGIN_AH_NAMESPACE
+
+/**
+ * @brief   A class for reading multiplexed analog inputs.
+ *          Supports 74HC4067, 74HC4051, etc.
+ * 
+ * You can use many multiplexers on the same address lines if each of the 
+ * multiplexers has a different enable line.
+ * 
+ * @tparam  N 
+ *          The number of addressable pins.
+ * 
+ * @ingroup AH_ExtIO
+ */
+template <uint8_t N>
+class ShiftRegisterIn : public StaticSizeExtendedIOElement<N> {
+  public:
+    /**
+     * @brief   Create a new ShiftRegisterIn object on the given pins.
+     * 
+     * @param   dataPin
+     *          The analog input pin connected to the output of the multiplexer.
+     * @param   addressPins
+     *          An array of the pins connected to the address lines of the
+     *          multiplexer. (Labeled S0, S1, S2 ... in the datasheet.)
+     * @param   enablePin
+     *          The digital output pin connected to the enable pin of the
+     *          multiplexer. (Labeled Ē in the datasheet.)  
+     *          If you don't need the enable pin, you can use NO_PIN, which is 
+     *          the default.
+     */
+    ShiftRegisterIn(pin_t dataPin, pin_t clockPin, pin_t clockEnablePin, 
+                    pin_t loadPin)
+        : dataPin(dataPin), clockPin(clockPin), clockEnablePin(clockEnablePin), 
+          loadPin(loadPin){
+
+         }
+
+    /**
+     * @brief   Set the pin mode of the analog input pin.  
+     *          This allows you to enable the internal pull-up resistor, for
+     *          use with buttons or open-collector outputs.
+     * 
+     * @note    This applies to all pins of this multiplexer.  
+     *          This affects all pins of the multiplexer, because it has only
+     *          a single common pin.  
+     * 
+     * @param   pin
+     *          (Unused)
+     * @param   mode
+     *          The new mode of the input pin: 
+     *          either INPUT or INPUT_PULLUP.
+     */
+    void pinMode(pin_t pin, PinMode_t mode) override;
+
+    /**
+     * @copydoc pinMode
+     */
+    void pinModeBuffered(pin_t pin, PinMode_t mode) override;
+
+    /**
+     * @brief   The digitalWrite function is not implemented because writing an
+     *          output to a multiplexer is not useful.
+     */
+    void digitalWrite(pin_t, PinStatus_t) override // LCOV_EXCL_LINE
+        __attribute__((deprecated)) {}             // LCOV_EXCL_LINE
+
+    /**
+     * @copydoc digitalWrite
+     */
+    void digitalWriteBuffered(pin_t, PinStatus_t) override // LCOV_EXCL_LINE
+        __attribute__((deprecated)) {}                     // LCOV_EXCL_LINE
+
+    /**
+     * @brief   Read the digital state of the given input.
+     * 
+     * @param   pin
+     *          The multiplexer's pin number to read from.
+     */
+    int digitalRead(pin_t pin) override;
+
+    /**
+     * @copydoc digitalRead
+     */
+    int digitalReadBuffered(pin_t pin) override;
+
+    /**
+     * @brief   Read the analog value of the given input.
+     * 
+     * @param   pin
+     *          The multiplexer's pin number to read from.
+     */
+    analog_t analogRead(pin_t pin) override;
+
+    /**
+     * @copydoc analogRead
+     */
+    analog_t analogReadBuffered(pin_t pin) override;
+
+    /**
+     * @brief   The analogWrite function is not implemented because writing an
+     *          output to a multiplexer is not useful.
+     */
+    void analogWrite(pin_t, analog_t) override // LCOV_EXCL_LINE
+        __attribute__((deprecated)) {}         // LCOV_EXCL_LINE
+
+    /**
+     * @copydoc analogWrite
+     */
+    void analogWriteBuffered(pin_t, analog_t) override // LCOV_EXCL_LINE
+        __attribute__((deprecated)) {}                 // LCOV_EXCL_LINE
+
+    /**
+     * @brief   Initialize the multiplexer: set the pin mode of the address pins
+     *          and the enable pin to output mode.
+     */
+    void begin() override;
+
+    void read();
+
+    /**
+     * @brief   No periodic updating of the state is necessary, all actions are 
+     *          carried out when the user calls analogRead or digitalRead.
+     */
+    void updateBufferedOutputs() override {} // LCOV_EXCL_LINE
+
+    void updateBufferedInputs() override;
+
+  private:
+    const pin_t dataPin;
+    const pin_t clockPin;
+    const pin_t clockEnablePin;
+    const pin_t loadPin; 
+
+    uint8_t buffer;
+
+    /**
+     * @brief   Enable the shift register.
+     */
+    void prepareReading();
+
+    /**
+     * @brief   Disable the shift register.
+     */
+    void afterReading();
+};
+
+/**
+ * @brief   An alias for ShiftRegisterIn<3> to use with CD74HC165 shift 
+ *          registers.
+ * 
+ * @ingroup AH_ExtIO
+ */
+using CD74HC165 = ShiftRegisterIn<8>;
+
+// -------------------------------------------------------------------------- //
+
+template <uint8_t N>
+void ShiftRegisterIn<N>::pinMode(pin_t, PinMode_t mode) {
+    ExtIO::pinMode(dataPin, mode);
+}
+
+template <uint8_t N>
+void ShiftRegisterIn<N>::pinModeBuffered(pin_t, PinMode_t mode) {
+    ShiftRegisterIn<N>::pinMode(dataPin, mode);
+}
+
+template <uint8_t N>
+int ShiftRegisterIn<N>::digitalRead(pin_t pin) {
+    return bitRead(buffer, pin);
+}
+
+template <uint8_t N>
+int ShiftRegisterIn<N>::digitalReadBuffered(pin_t pin) {
+    return bitRead(buffer, pin);
+}
+
+template <uint8_t N>
+analog_t ShiftRegisterIn<N>::analogRead(pin_t pin) {
+    return pin;
+}
+
+template <uint8_t N>
+analog_t ShiftRegisterIn<N>::analogReadBuffered(pin_t pin) {
+    return ShiftRegisterIn<N>::analogRead(pin);
+}
+
+template <uint8_t N>
+void ShiftRegisterIn<N>::begin() {
+    ExtIO::pinMode(clockPin, OUTPUT);
+    ExtIO::pinMode(clockEnablePin, OUTPUT);
+    ExtIO::pinMode(loadPin, OUTPUT);
+
+    ExtIO::digitalWrite(clockPin, LOW);
+    ExtIO::digitalWrite(loadPin, HIGH);
+    ExtIO::digitalWrite(clockEnablePin, HIGH);
+}
+
+template <uint8_t N>
+void ShiftRegisterIn<N>::updateBufferedInputs() {
+    prepareReading();
+    
+    buffer = shiftIn(dataPin, clockPin, LSBFIRST);
+
+    afterReading();
+}
+
+template <uint8_t N>
+void ShiftRegisterIn<N>::prepareReading() {
+    ExtIO::digitalWrite(loadPin, LOW);
+    ExtIO::digitalWrite(loadPin, HIGH);
+    ExtIO::digitalWrite(clockEnablePin, LOW);
+}
+
+template <uint8_t N>
+void ShiftRegisterIn<N>::afterReading() {
+    ExtIO::digitalWrite(clockEnablePin, HIGH);
+}
+
+END_AH_NAMESPACE
+
+AH_DIAGNOSTIC_POP()

--- a/src/AH/Hardware/ExtendedInputOutput/keywords.yml
+++ b/src/AH/Hardware/ExtendedInputOutput/keywords.yml
@@ -17,6 +17,9 @@ keyword1:
 
   - StaticSizeExtendedIOElement
 
+  - ShiftRegisterIn
+  - CD74HC165
+
 keyword2:
   - begin
   - update

--- a/src/Control_Surface.h
+++ b/src/Control_Surface.h
@@ -129,6 +129,7 @@
 #include <AH/Hardware/ExtendedInputOutput/MAX7219.hpp>
 #include <AH/Hardware/ExtendedInputOutput/SPIShiftRegisterOut.hpp>
 #include <AH/Hardware/ExtendedInputOutput/ShiftRegisterOut.hpp>
+#include <AH/Hardware/ExtendedInputOutput/ShiftRegisterIn.hpp>
 
 // ----------------------------- MIDI Constants ----------------------------- //
 #include <MIDI_Constants/Chords/Chords.hpp>

--- a/test/AH/Hardware/ExtendedInputOutput/test-ShiftRegisterIn.cpp
+++ b/test/AH/Hardware/ExtendedInputOutput/test-ShiftRegisterIn.cpp
@@ -1,0 +1,55 @@
+#include <gtest-wrapper.h>
+
+#include <AH/Hardware/ExtendedInputOutput/ShiftRegisterIn.hpp>
+#include <AH/Hardware/ExtendedInputOutput/ExtendedInputOutput.hpp>
+
+USING_AH_NAMESPACE;
+
+TEST(ShiftRegisterIn, analogReadNoEnable) {
+    /*
+    ISSUE: disabled because shiftIn and bitRead are not defined when building
+    tests
+
+    
+    ShiftRegisterIn<8> sr = {2, 3, 4, 5};
+
+
+    DEBUGFN(sr.getStart());
+    DEBUGFN(sr.getEnd());
+
+    EXPECT_CALL(ArduinoMock::getInstance(), pinMode(2, OUTPUT));
+    EXPECT_CALL(ArduinoMock::getInstance(), pinMode(3, OUTPUT));
+    EXPECT_CALL(ArduinoMock::getInstance(), pinMode(4, OUTPUT));
+    EXPECT_CALL(ArduinoMock::getInstance(), pinMode(5, OUTPUT));
+    ExtendedIOElement::beginAll();
+
+    ::testing::Mock::VerifyAndClear(&ArduinoMock::getInstance());
+
+    EXPECT_CALL(ArduinoMock::getInstance(), digitalWrite(2, 0));
+    EXPECT_CALL(ArduinoMock::getInstance(), digitalWrite(3, 0));
+    EXPECT_CALL(ArduinoMock::getInstance(), digitalWrite(4, 0));
+    EXPECT_CALL(ArduinoMock::getInstance(), digitalWrite(5, 0));
+    EXPECT_CALL(ArduinoMock::getInstance(), analogRead(A0)).Times(2);
+    ExtIO::analogRead(sr.pin(0b0000));
+
+    ::testing::Mock::VerifyAndClear(&ArduinoMock::getInstance());
+
+    EXPECT_CALL(ArduinoMock::getInstance(), digitalWrite(2, 1));
+    EXPECT_CALL(ArduinoMock::getInstance(), digitalWrite(3, 1));
+    EXPECT_CALL(ArduinoMock::getInstance(), digitalWrite(4, 1));
+    EXPECT_CALL(ArduinoMock::getInstance(), digitalWrite(5, 1));
+    EXPECT_CALL(ArduinoMock::getInstance(), analogRead(A0)).Times(2);
+    ExtIO::analogRead(sr.pin(0b1111));
+
+    ::testing::Mock::VerifyAndClear(&ArduinoMock::getInstance());
+
+    EXPECT_CALL(ArduinoMock::getInstance(), digitalWrite(2, 0));
+    EXPECT_CALL(ArduinoMock::getInstance(), digitalWrite(3, 1));
+    EXPECT_CALL(ArduinoMock::getInstance(), digitalWrite(4, 0));
+    EXPECT_CALL(ArduinoMock::getInstance(), digitalWrite(5, 1));
+    EXPECT_CALL(ArduinoMock::getInstance(), analogRead(A0)).Times(2);
+    ExtIO::analogRead(sr.pin(0b1010));
+
+    ::testing::Mock::VerifyAndClear(&ArduinoMock::getInstance());
+    */
+}


### PR DESCRIPTION
This adds support for reading from the digital inputs on a CD74HC165 shift-in register.  I based this on the multiplexer code and tested it in my own Arduino code.  I'm on a Mac, so some of the build commands did not work and I added Mac equivalents to tasks.json.  However, the arduino-example-builder exe does not run on Mac and I could not find a Mac equivalent.

the implementation uses `bitRead` and `shiftIn` from the Arduino library and compiles fine, but when trying to add tests, these are not defined.  should they be?  or do we need our own implementation of these methods?

as is, the test class is not useful - it's a placeholder.  I'm happy to flesh it out when the missing Arduino methods are solved.