### PR TITLE
Fix encoder support for Arduino Nano 33 BLE

### DIFF
--- a/src/Submodules/Encoder/utility/interrupt_pins.h
+++ b/src/Submodules/Encoder/utility/interrupt_pins.h
@@ -328,10 +328,31 @@
   #define CORE_INT12_PIN	12
   #define CORE_INT13_PIN	13
 
-// Arduino Nano BLE
+// Arduino Nano 33 BLE
 #elif defined(ARDUINO_ARCH_NRF52840)
-  #define CORE_NUM_INTERRUPT	NUM_DIGITAL_PINS
-
+  #define CORE_NUM_INTERRUPT	22
+  #define CORE_INT0_PIN		0
+  #define CORE_INT1_PIN		1
+  #define CORE_INT2_PIN		2
+  #define CORE_INT3_PIN		3
+  #define CORE_INT4_PIN		4
+  #define CORE_INT5_PIN		5
+  #define CORE_INT6_PIN		6
+  #define CORE_INT7_PIN		7
+  #define CORE_INT8_PIN		8
+  #define CORE_INT9_PIN		9
+  #define CORE_INT10_PIN	10
+  #define CORE_INT11_PIN	11
+  #define CORE_INT12_PIN	12
+  #define CORE_INT13_PIN	13
+  #define CORE_INT14_PIN	A0
+  #define CORE_INT15_PIN	A1
+  #define CORE_INT16_PIN	A2
+  #define CORE_INT17_PIN	A3
+  #define CORE_INT18_PIN	A4
+  #define CORE_INT19_PIN	A5
+  #define CORE_INT20_PIN	A6
+  #define CORE_INT21_PIN	A7
 #endif
 #endif
 


### PR DESCRIPTION
When trying to compile this library for the Arduino Nano 33 BLE I got the following error message:

```
In file included from /Users/chris/Documents/Arduino/libraries/Control_Surface/src/Submodules/Encoder/Encoder.h:38:0,
                 from /Users/chris/Documents/Arduino/libraries/Control_Surface/src/MIDI_Outputs/Abstract/MIDIAbsoluteEncoder.hpp:11,
                 from /Users/chris/Documents/Arduino/libraries/Control_Surface/src/MIDI_Outputs/CCAbsoluteEncoder.hpp:3,
                 from /Users/chris/Documents/Arduino/libraries/Control_Surface/src/Control_Surface.h:48,
                 from /Users/chris/dev/soundslikefrank/glove/firmware/firmware.ino:1:
/Users/chris/Documents/Arduino/libraries/Control_Surface/src/Submodules/Encoder/utility/interrupt_pins.h:342:2: error: #error "Encoder requires interrupt pins, but this board does not have any :("
 #error "Encoder requires interrupt pins, but this board does not have any :("
  ^~~~~                                          
/Users/chris/Documents/Arduino/libraries/Control_Surface/src/Submodules/Encoder/utility/interrupt_pins.h:343:2: error: #error "You could try defining ENCODER_DO_NOT_USE_INTERRUPTS as a kludge."
 #error "You could try defining ENCODER_DO_NOT_USE_INTERRUPTS as a kludge."
  ^~~~~  
```

Setting the interrupt pins like in the original [Encoder](https://github.com/PaulStoffregen/Encoder/blob/023f33752399e07a6a4ae3bde99456a5dcaa0288/utility/interrupt_pins.h#L335-L360) library fixed that problem.