### PR TITLE
Fetch googletest

### DIFF
--- a/mock/CMakeLists.txt
+++ b/mock/CMakeLists.txt
@@ -1,4 +1,13 @@
-find_package(GTest REQUIRED CONFIG)
+include(FetchContent)
+
+FetchContent_Declare(
+  googletest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG        v1.13.0
+)
+FetchContent_MakeAvailable(googletest)
+add_library(GTest::GTest INTERFACE IMPORTED)
+target_link_libraries(GTest::GTest INTERFACE gtest_main)
 
 add_library(ArduinoMock
     "Core/Arduino.cpp"


### PR DESCRIPTION
Hello,
Many thanks for that nice framework !

When I try to compile I get the following error:

```
❯ cmake ..
-- The CXX compiler identification is GNU 11.4.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found Doxygen: /usr/bin/doxygen (found version "1.9.1") found components: doxygen dot 
-- Found Python3: /usr/bin/python3.10 (found version "3.10.12") found components: Interpreter 
CMake Error at mock/CMakeLists.txt:1 (find_package):
  Could not find a package configuration file provided by "GTest" with any of
  the following names:

    GTestConfig.cmake
    gtest-config.cmake

  Add the installation prefix of "GTest" to CMAKE_PREFIX_PATH or set
  "GTest_DIR" to a directory containing one of the above files.  If "GTest"
  provides a separate development package or SDK, be sure it has been
  installed.


-- Configuring incomplete, errors occurred!
```

CMake can automatically download the dependency in the bulild directory