### PR TITLE
Add MIDIAddressable and MIDIAddressableUnsafe abstract classes

### DIFF
--- a/src/MIDI_Outputs/Abstract/MIDIAbsoluteEncoder.hpp
+++ b/src/MIDI_Outputs/Abstract/MIDIAbsoluteEncoder.hpp
@@ -6,6 +6,7 @@
 #include <Def/TypeTraits.hpp>
 #include <MIDI_Outputs/Abstract/EncoderState.hpp>
 #include <MIDI_Outputs/Abstract/MIDIOutputElement.hpp>
+#include <MIDI_Outputs/Abstract/MIDIAddressable.hpp>
 
 #ifdef ARDUINO
 #include <Submodules/Encoder/AHEncoder.hpp>
@@ -22,12 +23,13 @@ BEGIN_CS_NAMESPACE
  *          events.
  */
 template <class Enc, class Sender>
-class GenericMIDIAbsoluteEncoder : public MIDIOutputElement {
+class GenericMIDIAbsoluteEncoder : public MIDIOutputElement, public MIDIAddressable {
   public:
     GenericMIDIAbsoluteEncoder(Enc &&encoder, MIDIAddress address,
                                int16_t speedMultiply, uint8_t pulsesPerStep,
                                const Sender &sender)
-        : encoder(std::forward<Enc>(encoder)), address(address),
+        : MIDIAddressable(address),
+          encoder(std::forward<Enc>(encoder)),
           encstate(speedMultiply, pulsesPerStep), sender(sender) {}
 
     void begin() override { begin_if_possible(encoder); }
@@ -67,11 +69,6 @@ class GenericMIDIAbsoluteEncoder : public MIDIOutputElement {
     }
     int16_t getSpeedMultiply() const { return encstate.getSpeedMultiply(); }
 
-    /// Get the MIDI address.
-    MIDIAddress getAddress() const { return this->address; }
-    /// Set the MIDI address.
-    void setAddress(MIDIAddress address) { this->address = address; }
-
     int16_t resetPositionOffset() {
         auto encval = encoder.read();
         return encstate.update(encval);
@@ -79,7 +76,6 @@ class GenericMIDIAbsoluteEncoder : public MIDIOutputElement {
 
   private:
     Enc encoder;
-    MIDIAddress address;
     int16_t value = 0;
     EncoderState<decltype(encoder.read())> encstate;
 

--- a/src/MIDI_Outputs/Abstract/MIDIAddressable.cpp
+++ b/src/MIDI_Outputs/Abstract/MIDIAddressable.cpp
@@ -1,0 +1,3 @@
+#ifdef TEST_COMPILE_ALL_HEADERS_SEPARATELY
+#include "MIDIAddressable.hpp"
+#endif

--- a/src/MIDI_Outputs/Abstract/MIDIAddressable.hpp
+++ b/src/MIDI_Outputs/Abstract/MIDIAddressable.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <Def/MIDIAddress.hpp>
+
+BEGIN_CS_NAMESPACE
+
+/**
+ * @brief   An abstract class for output elements attached to an address.
+ *
+ * @see     MIDIAddress
+ */
+class MIDIAddressable
+{
+public:
+    /**
+     * @brief   Construct a new MIDIButton.
+     *
+     * @param   address
+     *          The MIDI address to send to.
+     */
+    MIDIAddressable(MIDIAddress address): address(address) {};
+
+    /// Get the MIDI address.
+    MIDIAddress getAddress() const { return this->address; }
+    /// Set the MIDI address.
+    void setAddress(MIDIAddress address) { this->address = address; }
+
+protected:
+    MIDIAddress address;
+};
+
+END_CS_NAMESPACE

--- a/src/MIDI_Outputs/Abstract/MIDIAddressableUnsafe.cpp
+++ b/src/MIDI_Outputs/Abstract/MIDIAddressableUnsafe.cpp
@@ -1,0 +1,3 @@
+#ifdef TEST_COMPILE_ALL_HEADERS_SEPARATELY
+#include "MIDIAddressableUnsafe.hpp"
+#endif

--- a/src/MIDI_Outputs/Abstract/MIDIAddressableUnsafe.hpp
+++ b/src/MIDI_Outputs/Abstract/MIDIAddressableUnsafe.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <Def/MIDIAddress.hpp>
+
+BEGIN_CS_NAMESPACE
+
+/**
+ * @brief   An abstract class for output elements attached to an address.
+ *
+ * @see     MIDIAddress
+ */
+class MIDIAddressableUnsafe
+{
+public:
+    /**
+     * @brief   Construct a new MIDIButton.
+     *
+     * @param   address
+     *          The MIDI address to send to.
+     */
+    MIDIAddressableUnsafe(MIDIAddress address): address(address) {};
+
+    /// Get the MIDI address.
+    MIDIAddress getAddress() const { return this->address; }
+    /// Set the MIDI address. Has unexpected consequences if used while a
+    /// push button is pressed. Use banks if you need to support that.
+    void setAddressUnsafe(MIDIAddress address) { this->address = address; }
+
+protected:
+    MIDIAddress address;
+};
+
+END_CS_NAMESPACE

--- a/src/MIDI_Outputs/Abstract/MIDIButton.hpp
+++ b/src/MIDI_Outputs/Abstract/MIDIButton.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
+#include "MIDIOutputElement.hpp"
 #include <AH/Hardware/Button.hpp>
 #include <Def/Def.hpp>
 #include <MIDI_Outputs/Abstract/MIDIOutputElement.hpp>
+#include <MIDI_Outputs/Abstract/MIDIAddressableUnsafe.hpp>
 
 BEGIN_CS_NAMESPACE
 
@@ -14,7 +16,7 @@ BEGIN_CS_NAMESPACE
  * @see     Button
  */
 template <class Sender>
-class MIDIButton : public MIDIOutputElement {
+class MIDIButton : public MIDIOutputElement, public MIDIAddressableUnsafe {
   public:
     /**
      * @brief   Construct a new MIDIButton.
@@ -28,7 +30,7 @@ class MIDIButton : public MIDIOutputElement {
      *          The MIDI sender to use.
      */
     MIDIButton(pin_t pin, MIDIAddress address, const Sender &sender)
-        : button(pin), address(address), sender(sender) {}
+        : MIDIAddressableUnsafe(address), button(pin), sender(sender) {}
 
     void begin() override { button.begin(); }
     void update() override {
@@ -45,15 +47,8 @@ class MIDIButton : public MIDIOutputElement {
 
     AH::Button::State getButtonState() const { return button.getState(); }
 
-    /// Get the MIDI address.
-    MIDIAddress getAddress() const { return this->address; }
-    /// Set the MIDI address. Has unexpected consequences if used while the
-    /// push button is pressed. Use banks if you need to support that.
-    void setAddressUnsafe(MIDIAddress address) { this->address = address; }
-
   private:
     AH::Button button;
-    const MIDIAddress address;
 
   public:
     Sender sender;

--- a/src/MIDI_Outputs/Abstract/MIDIButtonLatchable.hpp
+++ b/src/MIDI_Outputs/Abstract/MIDIButtonLatchable.hpp
@@ -4,8 +4,7 @@
 
 #include <AH/Hardware/Button.hpp>
 #include <Def/Def.hpp>
-#include <MIDI_Outputs/Abstract/MIDIOutputElement.hpp>
-#include <MIDI_Outputs/Abstract/MIDIAddressableUnsafe.hpp>
+#include <MIDI_Outputs/Abstract/MIDIOutputElementUnsafe.hpp>
 
 BEGIN_CS_NAMESPACE
 
@@ -18,7 +17,7 @@ BEGIN_CS_NAMESPACE
  * @see     Button
  */
 template <class Sender>
-class MIDIButtonLatched : public MIDIOutputElement, public MIDIAddressableUnsafe {
+class MIDIButtonLatchable : public MIDIOutputElementUnsafe {
   protected:
     /**
      * @brief   Create a new MIDIButtonLatched object on the given pin and 
@@ -33,7 +32,7 @@ class MIDIButtonLatched : public MIDIOutputElement, public MIDIAddressableUnsafe
      *          The MIDI sender to use.
      */
     MIDIButtonLatched(pin_t pin, MIDIAddress address, const Sender &sender)
-        : MIDIAddressableUnsafe(address), button(pin), sender(sender) {}
+        : button(pin), address(address), sender(sender) {}
 
   public:
     void begin() final override { button.begin(); }

--- a/src/MIDI_Outputs/Abstract/MIDIButtonLatching.hpp
+++ b/src/MIDI_Outputs/Abstract/MIDIButtonLatching.hpp
@@ -3,6 +3,7 @@
 #include <AH/Hardware/Button.hpp>
 #include <Def/Def.hpp>
 #include <MIDI_Outputs/Abstract/MIDIOutputElement.hpp>
+#include <MIDI_Outputs/Abstract/MIDIAddressable.hpp>
 
 BEGIN_CS_NAMESPACE
 
@@ -14,7 +15,7 @@ BEGIN_CS_NAMESPACE
  * @see     Button
  */
 template <class Sender>
-class MIDIButtonLatching : public MIDIOutputElement {
+class MIDIButtonLatching : public MIDIOutputElement, public MIDIAddressable {
   protected:
     /**
      * @brief   Construct a new MIDIButtonLatching.
@@ -28,7 +29,7 @@ class MIDIButtonLatching : public MIDIOutputElement {
      *          The MIDI sender to use.
      */
     MIDIButtonLatching(pin_t pin, MIDIAddress address, const Sender &sender)
-        : button(pin), address(address), sender(sender) {}
+        : MIDIAddressable(address), button(pin), sender(sender) {}
 
   public:
     void begin() override { button.begin(); }
@@ -42,14 +43,8 @@ class MIDIButtonLatching : public MIDIOutputElement {
 
     AH::Button::State getButtonState() const { return button.getState(); }
 
-    /// Get the MIDI address.
-    MIDIAddress getAddress() const { return this->address; }
-    /// Set the MIDI address.
-    void setAddress(MIDIAddress address) { this->address = address; }
-
   private:
     AH::Button button;
-    const MIDIAddress address;
 
   public:
     Sender sender;

--- a/src/MIDI_Outputs/Abstract/MIDIButtons.hpp
+++ b/src/MIDI_Outputs/Abstract/MIDIButtons.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
 #include <AH/Hardware/Button.hpp>
+#include <AH/Containers/Updatable.hpp>
 #include <Def/Def.hpp>
-#include <MIDI_Outputs/Abstract/MIDIOutputElement.hpp>
+#include <Def/MIDIAddress.hpp>
 
 BEGIN_CS_NAMESPACE
 
@@ -14,7 +15,7 @@ BEGIN_CS_NAMESPACE
  * @see     Button
  */
 template <class Sender, uint8_t NumButtons>
-class MIDIButtons : public MIDIOutputElement {
+class MIDIButtons : public AH::Updatable<> {
   protected:
     /**
      * @brief   Construct a new MIDIButtons.

--- a/src/MIDI_Outputs/Abstract/MIDIChordButton.hpp
+++ b/src/MIDI_Outputs/Abstract/MIDIChordButton.hpp
@@ -5,6 +5,7 @@
 #include <Def/Def.hpp>
 #include <MIDI_Constants/Chords/Chords.hpp>
 #include <MIDI_Outputs/Abstract/MIDIOutputElement.hpp>
+#include <MIDI_Outputs/Abstract/MIDIAddressableUnsafe.hpp>
 
 BEGIN_CS_NAMESPACE
 
@@ -17,7 +18,7 @@ BEGIN_CS_NAMESPACE
  * @see     AH::Button
  */
 template <class Sender>
-class MIDIChordButton : public MIDIOutputElement {
+class MIDIChordButton : public MIDIOutputElement, public MIDIAddressableUnsafe {
   public:
     /**
      * @brief   Construct a new MIDIChordButton.
@@ -40,7 +41,8 @@ class MIDIChordButton : public MIDIOutputElement {
     template <uint8_t N>
     MIDIChordButton(pin_t pin, MIDIAddress address, Chord<N> chord,
                     const Sender &sender)
-        : button(pin), address(address),
+        : MIDIAddressableUnsafe(address),
+          button(pin),
           newChord(AH::make_unique<Chord<N>>(std::move(chord))),
           sender(sender) {}
     // TODO: can I somehow get rid of the dynamic memory allocation here?
@@ -73,15 +75,8 @@ class MIDIChordButton : public MIDIOutputElement {
         newChord = AH::make_unique<Chord<N>>(std::move(chord));
     }
 
-    /// Get the MIDI address.
-    MIDIAddress getAddress() const { return this->address; }
-    /// Set the MIDI address. Has unexpected consequences if used while the
-    /// push button is pressed. Use banks if you need to support that.
-    void setAddressUnsafe(MIDIAddress address) { this->address = address; }
-
   private:
     AH::Button button;
-    MIDIAddress address;
     std::unique_ptr<const IChord> chord;
     std::unique_ptr<const IChord> newChord;
 

--- a/src/MIDI_Outputs/Abstract/MIDIFilteredAnalog.hpp
+++ b/src/MIDI_Outputs/Abstract/MIDIFilteredAnalog.hpp
@@ -3,6 +3,7 @@
 #include <AH/Hardware/FilteredAnalog.hpp>
 #include <Def/Def.hpp>
 #include <MIDI_Outputs/Abstract/MIDIOutputElement.hpp>
+#include <MIDI_Outputs/Abstract/MIDIAddressable.hpp>
 
 BEGIN_CS_NAMESPACE
 
@@ -14,7 +15,7 @@ BEGIN_CS_NAMESPACE
  * @see     FilteredAnalog
  */
 template <class Sender>
-class MIDIFilteredAnalog : public MIDIOutputElement {
+class MIDIFilteredAnalog : public MIDIOutputElement, public MIDIAddressable {
   protected:
     /**
      * @brief   Construct a new MIDIFilteredAnalog.
@@ -29,7 +30,7 @@ class MIDIFilteredAnalog : public MIDIOutputElement {
      */
     MIDIFilteredAnalog(pin_t analogPin, MIDIAddress address,
                        const Sender &sender)
-        : filteredAnalog(analogPin), address(address), sender(sender) {}
+        : MIDIAddressable(address), filteredAnalog(analogPin), sender(sender) {}
 
   public:
     void begin() final override { filteredAnalog.resetToCurrentValue(); }
@@ -72,14 +73,8 @@ class MIDIFilteredAnalog : public MIDIOutputElement {
      */
     analog_t getValue() const { return filteredAnalog.getValue(); }
 
-    /// Get the MIDI address.
-    MIDIAddress getAddress() const { return this->address; }
-    /// Set the MIDI address.
-    void setAddress(MIDIAddress address) { this->address = address; }
-
   private:
     AH::FilteredAnalog<Sender::precision()> filteredAnalog;
-    MIDIAddress address;
 
   public:
     Sender sender;

--- a/src/MIDI_Outputs/Abstract/MIDIIncrementDecrementButtons.hpp
+++ b/src/MIDI_Outputs/Abstract/MIDIIncrementDecrementButtons.hpp
@@ -3,6 +3,7 @@
 #include <AH/Hardware/IncrementDecrementButtons.hpp>
 #include <Def/Def.hpp>
 #include <MIDI_Outputs/Abstract/MIDIOutputElement.hpp>
+#include <MIDI_Outputs/Abstract/MIDIAddressable.hpp>
 
 #include <MIDI_Senders/DigitalNoteSender.hpp>
 
@@ -12,7 +13,7 @@ BEGIN_CS_NAMESPACE
  * @brief   An abstract class for two buttons that send incremental MIDI events.
  */
 template <class RelativeSender, class ResetSender>
-class MIDIIncrementDecrementButtons : public MIDIOutputElement {
+class MIDIIncrementDecrementButtons : public MIDIOutputElement, public MIDIAddressable {
   protected:
     /**
      * @brief   Construct a new MIDIIncrementDecrementButtons.
@@ -24,9 +25,10 @@ class MIDIIncrementDecrementButtons : public MIDIOutputElement {
                                   MIDIAddress resetAddress,
                                   const RelativeSender &relativeSender,
                                   const ResetSender &resetSender)
-        : buttons(buttons), address(address), multiplier(multiplier),
-          resetAddress(resetAddress), relativeSender(relativeSender),
-          resetSender(resetSender) {}
+        : MIDIAddressable(address),
+            buttons(buttons), multiplier(multiplier),
+            resetAddress(resetAddress), relativeSender(relativeSender),
+            resetSender(resetSender) {}
 
   public:
     void begin() override { buttons.begin(); }
@@ -68,11 +70,6 @@ class MIDIIncrementDecrementButtons : public MIDIOutputElement {
         return buttons.getState();
     }
 
-    /// Get the MIDI address.
-    MIDIAddress getAddress() const { return this->address; }
-    /// Set the MIDI address.
-    void setAddress(MIDIAddress address) { this->address = address; }
-
     /// Get the MIDI address of the reset action.
     MIDIAddress getResetAddress() const { return this->resetAddress; }
     /// Set the MIDI address of the reset action.
@@ -80,7 +77,6 @@ class MIDIIncrementDecrementButtons : public MIDIOutputElement {
 
   private:
     AH::IncrementDecrementButtons buttons;
-    MIDIAddress address;
     uint8_t multiplier;
     MIDIAddress resetAddress;
 

--- a/src/MIDI_Outputs/Abstract/MIDIRotaryEncoder.hpp
+++ b/src/MIDI_Outputs/Abstract/MIDIRotaryEncoder.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
+#include "MIDI_Outputs/Abstract/MIDIAddressable.hpp"
 #include <AH/STL/utility> // std::forward
 #include <Def/Def.hpp>
 #include <Def/TypeTraits.hpp>
 #include <MIDI_Outputs/Abstract/EncoderState.hpp>
 #include <MIDI_Outputs/Abstract/MIDIOutputElement.hpp>
+#include <MIDI_Outputs/Abstract/MIDIAddressable.hpp>
 
 #ifdef ARDUINO
 #include <Submodules/Encoder/AHEncoder.hpp>
@@ -20,7 +22,7 @@ BEGIN_CS_NAMESPACE
  * @brief   An abstract class for rotary encoders that send MIDI events.
  */
 template <class Enc, class Sender>
-class GenericMIDIRotaryEncoder : public MIDIOutputElement {
+class GenericMIDIRotaryEncoder : public MIDIOutputElement, public MIDIAddressable {
   public:
     /**
      * @brief   Construct a new MIDIRotaryEncoder.
@@ -30,7 +32,8 @@ class GenericMIDIRotaryEncoder : public MIDIOutputElement {
     GenericMIDIRotaryEncoder(Enc &&encoder, MIDIAddress address,
                              int16_t speedMultiply, uint8_t pulsesPerStep,
                              const Sender &sender)
-        : encoder(std::forward<Enc>(encoder)), address(address),
+        : MIDIAddressable(address),
+          encoder(std::forward<Enc>(encoder)),
           encstate(speedMultiply, pulsesPerStep), sender(sender) {}
 
     void begin() override { begin_if_possible(encoder); }
@@ -47,11 +50,6 @@ class GenericMIDIRotaryEncoder : public MIDIOutputElement {
     }
     int16_t getSpeedMultiply() const { return encstate.getSpeedMultiply(); }
 
-    /// Get the MIDI address.
-    MIDIAddress getAddress() const { return this->address; }
-    /// Set the MIDI address.
-    void setAddress(MIDIAddress address) { this->address = address; }
-
     int16_t resetPositionOffset() {
         auto encval = encoder.read();
         return encstate.update(encval);
@@ -59,7 +57,6 @@ class GenericMIDIRotaryEncoder : public MIDIOutputElement {
 
   private:
     Enc encoder;
-    MIDIAddress address;
     EncoderState<decltype(encoder.read())> encstate;
 
   public:


### PR DESCRIPTION
Hello,
Here is a change I made for a need I have.
I have a project of control surface with a set of push buttons. I wanted to make them configurable (via SysEx)
The two properties I want to configure is the CC address and whether it a latch or simple push button.
For that I needed an interface to call setAddressUnsafe() either for latch or simple button indifferently.

Of course I could use an array of MIDIOutputElements and cast CCButton/CCButtonLatched but it looks dirty to me.
See [an example](https://github.com/gwilherm/arduino-atmega32u4-midi-octopot/commit/6cd324b80148a17f844aead5056c78d9725c41f5)

The modification I made:
- New abstract class `MIDIAddressable` with `address` member + getter + setter
- New abstract class `MIDIAddressableUnsafe` with `address` member + getter + setter
- Every `MIDIOutputElement` with `setAddress()` inherits from `MIDIAddressable`
- Every `MIDIOutputElement` with `setAddressUnsafe()` inherits from `MIDIAddressableUnsafe`

Feel free to close if you think it is irrelevant ;-)