### PR TITLE
Fix compile error with Teensyduino 1.59.0 and Teensy++2.0 board

### DIFF
--- a/src/AH/STL/Fallback/new
+++ b/src/AH/STL/Fallback/new
@@ -88,7 +88,7 @@ namespace std
   enum class align_val_t: size_t {};
 #endif
 
-#if !defined(NEW_H) || defined(__AVR_ATmega4809__) // already defined in Arduino's version of <new>
+#if !defined(NEW_H) || defined(__AVR_ATmega4809__) || defined(ARDUINO_TEENSY2PP) // already defined in Arduino's version of <new>
   struct nothrow_t
   {
 #if __cplusplus >= 201103L
@@ -114,7 +114,7 @@ namespace std
 } // namespace std
 
 //@{
-#if !defined(NEW_H) || defined(__AVR_ATmega4809__) // already defined in Arduino's version of <new>
+#if !defined(NEW_H) || defined(__AVR_ATmega4809__) || defined(ARDUINO_TEENSY2PP) // already defined in Arduino's version of <new>
 /** These are replaceable signatures:
  *  - normal single new and delete (no arguments, throw @c bad_alloc on error)
  *  - normal array new and delete (same)


### PR DESCRIPTION
In https://forum.arduino.cc/t/gelost-teensy-2-0-fehler-compilation-error-exit-status-1/1417296 user [norbert](https://forum.arduino.cc/u/norbert) found the problem that the library does not compile with Teensyduino 1.59.0 and the Teensy++2.0 board.

This PR adds std::nothrow and operator new variants used by the bundled STL for Teensy++2.0.

