### PR TITLE
Add compiler defines for pico 2w to bluetooth MIDI

### DIFF
--- a/src/MIDI_Interfaces/BLEMIDI/BTstack/advertising.cpp
+++ b/src/MIDI_Interfaces/BLEMIDI/BTstack/advertising.cpp
@@ -1,4 +1,4 @@
-#if defined(ARDUINO_RASPBERRY_PI_PICO_W) && ENABLE_BLE
+#if (defined(ARDUINO_RASPBERRY_PI_PICO_W) || defined(ARDUINO_RASPBERRY_PI_PICO_2W)) && ENABLE_BLE
 
 #include <btstack.h>
 

--- a/src/MIDI_Interfaces/BLEMIDI/BTstack/gatt_midi.cpp
+++ b/src/MIDI_Interfaces/BLEMIDI/BTstack/gatt_midi.cpp
@@ -1,4 +1,4 @@
-#if defined(ARDUINO_RASPBERRY_PI_PICO_W) && ENABLE_BLE
+#if (defined(ARDUINO_RASPBERRY_PI_PICO_W) || defined(ARDUINO_RASPBERRY_PI_PICO_2W)) && ENABLE_BLE
 
 #define BTSTACK_FILE__ "gatt_midi.cpp"
 

--- a/src/MIDI_Interfaces/BluetoothMIDI_Interface.hpp
+++ b/src/MIDI_Interfaces/BluetoothMIDI_Interface.hpp
@@ -57,7 +57,7 @@ END_CS_NAMESPACE
 #endif
 #endif
 
-#elif defined(ARDUINO_RASPBERRY_PI_PICO_W)
+#elif (defined(ARDUINO_RASPBERRY_PI_PICO_W) || defined(ARDUINO_RASPBERRY_PI_PICO_2W))
 // Pico W
 #if ENABLE_BLE
 #include "BLEMIDI/BTstackBackgroundBackend.hpp"


### PR DESCRIPTION
Fixes linker errors when compiling bluetooth on Pico 2W.

Without this, the compiler defines block the BTstack libraries from being included, as Pico 2W does not define itself as `ARDUINO_RASPBERRY_PI_PICO_W`, but rather `ARDUINO_RASPBERRY_PI_PICO_2W`. This creates linker errors (full example at the bottom) when using the bluetooth interface, that are
```
undefined reference to:
cs::midi_ble_btstack::init(...)
cs::midi_ble_btstack::notify(...)
```

Patch successfully tested on:
* Pico 2W; Arduino IDE; earlephilhower core.
* Before patching, fails to compile.
* After patching, the Pico 2W connects successfully to iPhone running SynthOne synth app, over bluetooth MIDI with the BLEMIDI-Adapter.ino example sketch. Sending DIN-MIDI notes to the Pico 2W. The iPhone receives the BLEMIDI note data, and plays the notes as expected.
* Note that currently it does not connect to Windows BLE, even though Windows sees it (I see there's a separate patch for this available by others, but I wanted to call it out in case anyone was testing...)

```
C:/Users/tuuli/AppData/Local/Arduino15/packages/rp2040/tools/pqt-gcc/4.1.0-1aec55e/bin/../lib/gcc/arm-none-eabi/14.3.0/../../../../arm-none-eabi/bin/ld.exe: C:\Users\tuuli\AppData\Local\arduino\sketches\1F34AB46E657C3158B50031EA2CC6398\sketch\BLEMIDI-Adapter.ino.cpp.o: in function `_ZN2cs24BTstackBackgroundBackend5beginENS_11BLESettingsE':
c:\Users\tuuli\Documents\Arduino\libraries\Control_Surface\src/MIDI_Interfaces/BLEMIDI/BTstackBackgroundBackend.hpp:103:(.text._ZN2cs24GenericBLEMIDI_InterfaceINS_24BTstackBackgroundBackendEE5beginEv[_ZN2cs24GenericBLEMIDI_InterfaceINS_24BTstackBackgroundBackendEE5beginEv]+0x1e): undefined reference to `_ZN2cs16midi_ble_btstack4initERNS_15MIDIBLEInstanceENS_11BLESettingsE'

C:/Users/tuuli/AppData/Local/Arduino15/packages/rp2040/tools/pqt-gcc/4.1.0-1aec55e/bin/../lib/gcc/arm-none-eabi/14.3.0/../../../../arm-none-eabi/bin/ld.exe: C:\Users\tuuli\AppData\Local\arduino\sketches\1F34AB46E657C3158B50031EA2CC6398\sketch\BLEMIDI-Adapter.ino.cpp.o: in function `_ZN2cs24BTstackBackgroundBackend8sendDataENS_11BLEDataViewE':

c:\Users\tuuli\Documents\Arduino\libraries\Control_Surface\src/MIDI_Interfaces/BLEMIDI/BTstackBackgroundBackend.hpp:119:(.text._ZN2cs20PollingBLEMIDISenderINS_24BTstackBackgroundBackendEE7sendNowERNS2_16ProtectedBuilderE[_ZN2cs20PollingBLEMIDISenderINS_24BTstackBackgroundBackendEE7sendNowERNS2_16ProtectedBuilderE]+0x32): 
undefined reference to 
`_ZN2cs16midi_ble_btstack6notifyENS_19BLEConnectionHandleENS_23BLECharacteristicHandleENS_11BLEDataViewE'
collect2.exe: error: ld returned 1 exit status
```
